### PR TITLE
Aggiunto supporto LED e nuovo esempio Sequencer

### DIFF
--- a/Artboard.cpp
+++ b/Artboard.cpp
@@ -15,7 +15,8 @@ const int POT_PINS[8] = {31, 32, 33, 34, 35, 36, 37, 38};
 **/
 Artboard::Artboard() {
 	_isInitialized = false; // Sarà impostato a true da initialize()
-	signalPin = -1; 
+	_ledsInitialized = false; // Sarà impostato a true da initLEDs()
+	signalPin = -1;
 	enablePin = -1;
 	currentChannel = -1;
 	currentChannelB = -1;
@@ -191,6 +192,95 @@ void Artboard::setButtonChannel(int channel){
         // AGGIUNGI QUESTA RIGA:
         // Dà al MUX il tempo di stabilizzarsi prima della lettura.
         // 1 microsecondo (1000ns) è un'eternità per un MUX da 50ns.
-        delayMicroseconds(1); 
+        delayMicroseconds(1);
 	}
+}
+
+
+// --- LED FUNCTIONS ---
+
+/**
+* @public
+* Inizializza i LED
+*/
+void Artboard::initLEDs() {
+	if (_ledsInitialized) return; // Già inizializzato
+
+	FastLED.addLeds<LED_TYPE, LED_DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+	FastLED.setBrightness(128); // Luminosità media di default
+	FastLED.clear();
+	FastLED.show();
+
+	_ledsInitialized = true;
+}
+
+/**
+* @public
+* Imposta il colore di un LED specifico
+*/
+void Artboard::setLED(uint8_t index, uint8_t r, uint8_t g, uint8_t b) {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	if (index >= NUM_LEDS) return; // Indice non valido
+
+	leds[index] = CRGB(r, g, b);
+	FastLED.show();
+}
+
+/**
+* @public
+* Imposta il colore di tutti i LED
+*/
+void Artboard::setAllLEDs(uint8_t r, uint8_t g, uint8_t b) {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	for (int i = 0; i < NUM_LEDS; i++) {
+		leds[i] = CRGB(r, g, b);
+	}
+	FastLED.show();
+}
+
+/**
+* @public
+* Spegne un LED specifico
+*/
+void Artboard::clearLED(uint8_t index) {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	if (index >= NUM_LEDS) return; // Indice non valido
+
+	leds[index] = CRGB(0, 0, 0);
+	FastLED.show();
+}
+
+/**
+* @public
+* Spegne tutti i LED
+*/
+void Artboard::clearAllLEDs() {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	FastLED.clear();
+	FastLED.show();
+}
+
+/**
+* @public
+* Aggiorna i LED
+*/
+void Artboard::updateLEDs() {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	FastLED.show();
+}
+
+/**
+* @public
+* Imposta la luminosità globale
+*/
+void Artboard::setBrightness(uint8_t brightness) {
+	if (!_ledsInitialized) initLEDs(); // Init automatico
+
+	FastLED.setBrightness(brightness);
+	FastLED.show();
 }

--- a/Artboard.h
+++ b/Artboard.h
@@ -2,19 +2,26 @@
 #define Artboard_h
 
 #include "Arduino.h"
+#include <FastLED.h>
 
 #define Artboard_IO_READ 0
 #define Artboard_IO_WRITE 1
 
+// LED Configuration
+#define NUM_LEDS 8
+#define LED_DATA_PIN 8
+#define LED_TYPE WS2812B
+#define COLOR_ORDER GRB
+
 class Artboard {
   public:
     // --- Funzioni Pubbliche ---
-    
+
     /**
     * Costruttore
     */
     Artboard();
-    
+
     /**
     * Abilita o disabilita il MUX (se enPin è usato)
     */
@@ -45,6 +52,53 @@ class Artboard {
     */
     void write(int channel, int value);
 
+    // --- LED Functions ---
+
+    /**
+    * Inizializza i LED (chiamata automaticamente)
+    */
+    void initLEDs();
+
+    /**
+    * Imposta il colore di un LED specifico (0-7)
+    * @param index indice del LED (0-7)
+    * @param r valore rosso (0-255)
+    * @param g valore verde (0-255)
+    * @param b valore blu (0-255)
+    */
+    void setLED(uint8_t index, uint8_t r, uint8_t g, uint8_t b);
+
+    /**
+    * Imposta il colore di tutti i LED
+    * @param r valore rosso (0-255)
+    * @param g valore verde (0-255)
+    * @param b valore blu (0-255)
+    */
+    void setAllLEDs(uint8_t r, uint8_t g, uint8_t b);
+
+    /**
+    * Spegne un LED specifico
+    * @param index indice del LED (0-7)
+    */
+    void clearLED(uint8_t index);
+
+    /**
+    * Spegne tutti i LED
+    */
+    void clearAllLEDs();
+
+    /**
+    * Aggiorna i LED (mostra le modifiche)
+    * Chiamata automaticamente dopo setLED(), ma può essere chiamata manualmente
+    */
+    void updateLEDs();
+
+    /**
+    * Imposta la luminosità globale dei LED
+    * @param brightness valore luminosità (0-255)
+    */
+    void setBrightness(uint8_t brightness);
+
   private:
     // --- Funzioni Private ---
 
@@ -52,7 +106,7 @@ class Artboard {
     * Esegue il setup dei pin una sola volta
     */
     void initialize();
-    
+
     /**
     * Imposta il canale per il MUX touch (pin 2-5)
     */
@@ -65,11 +119,15 @@ class Artboard {
 
     // --- Variabili Membro (Private) ---
     bool _isInitialized; // Flag per setup automatico
+    bool _ledsInitialized; // Flag per setup LED
     int signalPin;
     int enablePin;
     int currentChannel;  // Canale MUX Touch
     int currentChannelB; // Canale MUX Bottoni
     int lastIO;
+
+    // LED array
+    CRGB leds[NUM_LEDS];
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Libreria Arduino per breakout board Teensy 3.6.
    - **Windows**: `Documents/Arduino/libraries/`
    - **Mac**: `~/Documents/Arduino/libraries/`
    - **Linux**: `~/Arduino/libraries/`
-3. Riavvia Arduino IDE
+3. Installa la libreria **FastLED** tramite Library Manager (per il supporto LED RGB)
+4. Riavvia Arduino IDE
 
 Oppure installa tramite Arduino IDE:
 1. Vai su `Sketch` → `Include Library` → `Add .ZIP Library...`
 2. Seleziona il file ZIP scaricato
+3. Installa la libreria **FastLED** tramite Library Manager
 
 ## Utilizzo Base
 
@@ -94,6 +96,7 @@ La libreria include diversi esempi per iniziare rapidamente:
 
 ### Audio
 - **Artboard_PlayAudioFromSD**: Riproduzione di campioni audio da SD card
+- **Artboard_Sequencer**: Sequencer musicale a 8 step con sintetizzatore polifonico a 12 note
 - **audio/workshop**: Serie completa di esempi per sintesi audio e processing (w1-w11)
   - Sintesi sonora base, inviluppi, filtri, delay, LFO e altro
 
@@ -128,9 +131,15 @@ artboard.pot(pin)  // pin: 0-7, ritorna valore 0-1023
 
 ### LED RGB
 ```cpp
-artboard.setRGB(r, g, b)  // Imposta colore LED RGB principale
-artboard.setLED(index, r, g, b)  // Imposta LED digitale specifico (0-7)
+artboard.setLED(index, r, g, b)  // Imposta LED specifico (0-7)
+artboard.setAllLEDs(r, g, b)     // Imposta tutti i LED
+artboard.clearLED(index)         // Spegne LED specifico
+artboard.clearAllLEDs()          // Spegne tutti i LED
+artboard.setBrightness(value)    // Imposta luminosità (0-255)
+artboard.updateLEDs()            // Aggiorna i LED manualmente
 ```
+
+**Nota**: I LED usano la libreria FastLED e sono collegati al pin 8. Assicurati di avere FastLED installata.
 
 ### Pin Digitali/Analogici
 ```cpp

--- a/examples/Artboard_Sequencer/Artboard_Sequencer.ino
+++ b/examples/Artboard_Sequencer/Artboard_Sequencer.ino
@@ -1,0 +1,428 @@
+/*
+ * Artboard Sequencer
+ *
+ * Un sequencer a 8 step con sintetizzatore polifonico a 12 note
+ *
+ * HARDWARE:
+ * - Touch (0-11): Suonano le 12 note (scala cromatica)
+ * - Pot 0:  Attack envelope
+ * - Pot 1:  Release envelope
+ * - Pot 2:  Mix tra oscillatore 1 e 2
+ * - Pot 3:  Forma d'onda oscillatore 1 (Sine, Saw, Square, Triangle)
+ * - Pot 4:  Forma d'onda oscillatore 2 (Sine, Saw, Square, Triangle)
+ * - Pot 5:  Filtro Cutoff
+ * - Pot 6:  LFO Rate (velocità modulazione)
+ * - Pot 7:  LFO Depth (intensità modulazione)
+ * - Pot 8:  Velocità del sequencer (BPM) - NOTA: Pot 8 non esiste su Artboard standard!
+ *           Usa Pot 7 per BPM se hai solo 8 pot, o aggiungi controllo esterno
+ *
+ * - Button (0-7): Seleziona step per registrazione
+ * - On/Off Switch (pin 28): Play/Stop sequencer
+ * - LED (0-7): Indicatore step corrente durante playback
+ *
+ * FUNZIONAMENTO:
+ * 1. Tenere premuto un pulsante (0-7) per selezionare uno step
+ * 2. Mentre tieni premuto il pulsante, suona le note con i touch
+ * 3. Le note suonate vengono registrate in quello step
+ * 4. Attiva lo switch (pin 28) per avviare il playback
+ * 5. Il sequencer suonerà le note registrate in sequenza
+ *
+ * by Daniele Murgia © 2025 MIT License
+ */
+
+#include <Artboard.h>
+#include <Audio.h>
+#include <Wire.h>
+#include <SPI.h>
+#include <SD.h>
+#include <SerialFlash.h>
+
+Artboard artboard;
+
+// --- AUDIO SETUP (Teensy Audio Design Tool) ---
+
+// Oscillatori (2 per ogni nota = 12 note x 2 = 24 oscillatori)
+AudioSynthWaveform osc1[12];
+AudioSynthWaveform osc2[12];
+
+// Envelopes per ogni nota
+AudioEffectEnvelope env[12];
+
+// Mixer per combinare osc1 e osc2 di ogni nota
+AudioMixer4 noteMixer[12];
+
+// Mixer principali (raggruppano le 12 note)
+AudioMixer4 mainMixer1;
+AudioMixer4 mainMixer2;
+AudioMixer4 mainMixer3;
+
+// LFO per modulazione filtro
+AudioSynthWaveformSine lfo;
+AudioSynthWaveformDc lfoDepth;
+AudioEffectMultiply lfoMult;
+
+// Filtro
+AudioFilterStateVariable filter;
+
+// Output
+AudioOutputI2S i2s1;
+
+// Connections
+AudioConnection* patchCords[200]; // Array per tenere traccia delle connessioni
+int patchCordIndex = 0;
+
+void setup() {
+  Serial.begin(115200);
+
+  // Audio memory
+  AudioMemory(120);
+
+  // Setup oscillatori e envelopes
+  setupAudioConnections();
+
+  // Setup iniziale forme d'onda e parametri
+  for (int i = 0; i < 12; i++) {
+    osc1[i].begin(WAVEFORM_SAWTOOTH);
+    osc2[i].begin(WAVEFORM_SQUARE);
+    osc1[i].amplitude(0.3);
+    osc2[i].amplitude(0.3);
+
+    // Imposta le frequenze delle note (scala cromatica da C3)
+    float freq = noteFrequency(i);
+    osc1[i].frequency(freq);
+    osc2[i].frequency(freq);
+
+    // Envelope settings
+    env[i].attack(10);
+    env[i].decay(0);
+    env[i].sustain(1.0);
+    env[i].release(200);
+
+    // Mixer delle note (combina osc1 e osc2)
+    noteMixer[i].gain(0, 0.5); // osc1
+    noteMixer[i].gain(1, 0.5); // osc2
+  }
+
+  // Mixer principali
+  mainMixer1.gain(0, 0.25);
+  mainMixer1.gain(1, 0.25);
+  mainMixer1.gain(2, 0.25);
+  mainMixer1.gain(3, 0.25);
+
+  mainMixer2.gain(0, 0.25);
+  mainMixer2.gain(1, 0.25);
+  mainMixer2.gain(2, 0.25);
+  mainMixer2.gain(3, 0.25);
+
+  mainMixer3.gain(0, 0.25);
+  mainMixer3.gain(1, 0.25);
+  mainMixer3.gain(2, 0.25);
+  mainMixer3.gain(3, 0.25);
+
+  // LFO
+  lfo.frequency(2.0);
+  lfo.amplitude(1.0);
+  lfoDepth.amplitude(0.5);
+
+  // Filtro
+  filter.frequency(2000);
+  filter.resonance(1.4);
+
+  // Setup pin on/off switch
+  pinMode(28, INPUT_PULLUP);
+
+  // Inizializza LED
+  artboard.clearAllLEDs();
+
+  Serial.println("=== ARTBOARD SEQUENCER ===");
+  Serial.println("Ready!");
+}
+
+// --- SEQUENCER DATA ---
+#define NUM_STEPS 8
+#define NUM_NOTES 12
+
+// Struttura per memorizzare lo stato di ogni step
+struct Step {
+  bool notes[NUM_NOTES];  // Quali note sono attive
+  bool hasData;           // Se lo step contiene dati
+};
+
+Step sequence[NUM_STEPS];
+
+// Variabili sequencer
+int currentStep = 0;
+unsigned long lastStepTime = 0;
+int bpm = 120;
+bool isPlaying = false;
+int recordingStep = -1; // -1 = nessuna registrazione in corso
+
+// Stato precedente dei controlli (per edge detection)
+bool prevTouchState[NUM_NOTES] = {false};
+bool prevButtonState[8] = {false};
+bool prevPlayState = false;
+
+void loop() {
+  // --- LEGGI CONTROLLI ---
+
+  // Attack e Release
+  int attackTime = map(artboard.pot(0), 0, 1023, 1, 500);
+  int releaseTime = map(artboard.pot(1), 0, 1023, 10, 1000);
+
+  // Mix oscillatori
+  float osc1Mix = map(artboard.pot(2), 0, 1023, 0, 100) / 100.0;
+  float osc2Mix = 1.0 - osc1Mix;
+
+  // Forme d'onda
+  int waveform1Type = map(artboard.pot(3), 0, 1023, 0, 3);
+  int waveform2Type = map(artboard.pot(4), 0, 1023, 0, 3);
+
+  // Filtro
+  int filterFreq = map(artboard.pot(5), 0, 1023, 100, 10000);
+
+  // LFO
+  float lfoRate = map(artboard.pot(6), 0, 1023, 1, 200) / 10.0;
+  float lfoDepthValue = map(artboard.pot(7), 0, 1023, 0, 100) / 100.0;
+
+  // BPM (usa pot 7 o aggiungi controllo esterno)
+  // Per ora usa un valore fisso o pot 7 in alternativa
+  // bpm = map(artboard.pot(7), 0, 1023, 40, 240);
+
+  // Play/Stop
+  bool playSwitch = (digitalRead(28) == LOW); // Assumendo switch pull-up
+
+  // --- AGGIORNA PARAMETRI AUDIO ---
+
+  // Aggiorna forme d'onda per tutti gli oscillatori
+  static int prevWaveform1Type = -1;
+  static int prevWaveform2Type = -1;
+
+  if (waveform1Type != prevWaveform1Type) {
+    short wf1 = getWaveformType(waveform1Type);
+    for (int i = 0; i < 12; i++) {
+      osc1[i].begin(wf1);
+      osc1[i].frequency(noteFrequency(i));
+      osc1[i].amplitude(0.3);
+    }
+    prevWaveform1Type = waveform1Type;
+  }
+
+  if (waveform2Type != prevWaveform2Type) {
+    short wf2 = getWaveformType(waveform2Type);
+    for (int i = 0; i < 12; i++) {
+      osc2[i].begin(wf2);
+      osc2[i].frequency(noteFrequency(i));
+      osc2[i].amplitude(0.3);
+    }
+    prevWaveform2Type = waveform2Type;
+  }
+
+  // Aggiorna mix oscillatori
+  for (int i = 0; i < 12; i++) {
+    noteMixer[i].gain(0, osc1Mix);
+    noteMixer[i].gain(1, osc2Mix);
+  }
+
+  // Aggiorna filtro
+  filter.frequency(filterFreq);
+
+  // Aggiorna LFO
+  lfo.frequency(lfoRate);
+  lfoDepth.amplitude(lfoDepthValue);
+
+  // Aggiorna envelope
+  for (int i = 0; i < 12; i++) {
+    env[i].attack(attackTime);
+    env[i].release(releaseTime);
+  }
+
+  // --- GESTIONE PULSANTI PER REGISTRAZIONE ---
+
+  recordingStep = -1;
+  for (int i = 0; i < 8; i++) {
+    bool btnState = (artboard.button(i) == HIGH);
+
+    // Rileva pressione pulsante (edge detection)
+    if (btnState && !prevButtonState[i]) {
+      // Nuovo step selezionato - pulisci i dati precedenti
+      sequence[i].hasData = false;
+      for (int n = 0; n < NUM_NOTES; n++) {
+        sequence[i].notes[n] = false;
+      }
+      Serial.print("Recording on step: ");
+      Serial.println(i);
+    }
+
+    if (btnState) {
+      recordingStep = i;
+      // Accendi LED per indicare registrazione
+      artboard.setLED(i, 255, 0, 0); // Rosso per registrazione
+    } else if (!btnState && prevButtonState[i]) {
+      // Pulsante rilasciato
+      artboard.clearLED(i);
+    }
+
+    prevButtonState[i] = btnState;
+  }
+
+  // --- GESTIONE TOUCH (SUONARE NOTE + REGISTRAZIONE) ---
+
+  for (int i = 0; i < NUM_NOTES; i++) {
+    int touchValue = artboard.touch(i);
+    bool touched = (touchValue > 2000); // Soglia touch
+
+    // Edge detection: nota appena toccata
+    if (touched && !prevTouchState[i]) {
+      // Trigger nota
+      env[i].noteOn();
+
+      // Se stiamo registrando, aggiungi la nota allo step
+      if (recordingStep >= 0) {
+        sequence[recordingStep].notes[i] = true;
+        sequence[recordingStep].hasData = true;
+        Serial.print("Recorded note ");
+        Serial.print(i);
+        Serial.print(" on step ");
+        Serial.println(recordingStep);
+      }
+    }
+
+    // Nota rilasciata
+    if (!touched && prevTouchState[i]) {
+      env[i].noteOff();
+    }
+
+    prevTouchState[i] = touched;
+  }
+
+  // --- SEQUENCER PLAYBACK ---
+
+  // Gestisci play/stop
+  if (playSwitch && !prevPlayState) {
+    // Play premuto
+    isPlaying = !isPlaying;
+    if (isPlaying) {
+      currentStep = 0;
+      lastStepTime = millis();
+      Serial.println("PLAY");
+    } else {
+      Serial.println("STOP");
+      artboard.clearAllLEDs();
+      // Spegni tutte le note
+      for (int i = 0; i < NUM_NOTES; i++) {
+        env[i].noteOff();
+      }
+    }
+  }
+  prevPlayState = playSwitch;
+
+  // Avanza sequencer
+  if (isPlaying) {
+    unsigned long stepDuration = (60000 / bpm) / 2; // Durata step in ms (2 step per beat)
+
+    if (millis() - lastStepTime >= stepDuration) {
+      // Avanza allo step successivo
+      lastStepTime = millis();
+
+      // Spegni note dello step precedente
+      for (int i = 0; i < NUM_NOTES; i++) {
+        env[i].noteOff();
+      }
+
+      // Avanza step
+      currentStep = (currentStep + 1) % NUM_STEPS;
+
+      // Aggiorna LED
+      artboard.clearAllLEDs();
+      artboard.setLED(currentStep, 0, 255, 0); // Verde per playback
+
+      // Suona le note dello step corrente
+      if (sequence[currentStep].hasData) {
+        for (int i = 0; i < NUM_NOTES; i++) {
+          if (sequence[currentStep].notes[i]) {
+            env[i].noteOn();
+          }
+        }
+      }
+    }
+  }
+
+  delay(1); // Piccolo delay per stabilità
+}
+
+// --- FUNZIONI HELPER ---
+
+// Calcola frequenza nota (scala cromatica da C3)
+float noteFrequency(int note) {
+  // Note: C, C#, D, D#, E, F, F#, G, G#, A, A#, B
+  float baseFreq = 130.81; // C3
+  return baseFreq * pow(2.0, note / 12.0);
+}
+
+// Converte indice in tipo di forma d'onda
+short getWaveformType(int index) {
+  switch(index) {
+    case 0: return WAVEFORM_SINE;
+    case 1: return WAVEFORM_SAWTOOTH;
+    case 2: return WAVEFORM_SQUARE;
+    case 3: return WAVEFORM_TRIANGLE;
+    default: return WAVEFORM_SINE;
+  }
+}
+
+// Setup delle connessioni audio
+void setupAudioConnections() {
+  // Questa è una versione semplificata
+  // In un progetto reale useresti il Teensy Audio Design Tool
+
+  // Per ogni nota: osc1 e osc2 -> noteMixer -> envelope -> mainMixer
+
+  // Esempio di connessioni per le prime note:
+  // NOTA: Teensy ha un limite di oggetti AudioConnection (circa 100-120)
+  // Per un progetto completo, potresti dover usare AudioMixer con meno canali
+  // o un approccio diverso
+
+  // Connetti oscillatori ai mixer delle note
+  for (int i = 0; i < 12; i++) {
+    patchCords[patchCordIndex++] = new AudioConnection(osc1[i], 0, noteMixer[i], 0);
+    patchCords[patchCordIndex++] = new AudioConnection(osc2[i], 0, noteMixer[i], 1);
+  }
+
+  // Connetti note mixer agli envelope e poi ai mixer principali
+  // Note 0-3 -> mainMixer1
+  for (int i = 0; i < 4; i++) {
+    patchCords[patchCordIndex++] = new AudioConnection(noteMixer[i], 0, env[i], 0);
+    patchCords[patchCordIndex++] = new AudioConnection(env[i], 0, mainMixer1, i);
+  }
+
+  // Note 4-7 -> mainMixer2
+  for (int i = 4; i < 8; i++) {
+    patchCords[patchCordIndex++] = new AudioConnection(noteMixer[i], 0, env[i], 0);
+    patchCords[patchCordIndex++] = new AudioConnection(env[i], 0, mainMixer2, i-4);
+  }
+
+  // Note 8-11 -> mainMixer3
+  for (int i = 8; i < 12; i++) {
+    patchCords[patchCordIndex++] = new AudioConnection(noteMixer[i], 0, env[i], 0);
+    patchCords[patchCordIndex++] = new AudioConnection(env[i], 0, mainMixer3, i-8);
+  }
+
+  // Setup LFO
+  patchCords[patchCordIndex++] = new AudioConnection(lfo, 0, lfoMult, 0);
+  patchCords[patchCordIndex++] = new AudioConnection(lfoDepth, 0, lfoMult, 1);
+
+  // Connetti mixer principali al filtro
+  patchCords[patchCordIndex++] = new AudioConnection(mainMixer1, 0, filter, 0);
+  patchCords[patchCordIndex++] = new AudioConnection(mainMixer2, 0, filter, 0);
+  patchCords[patchCordIndex++] = new AudioConnection(mainMixer3, 0, filter, 0);
+
+  // LFO modula il filtro
+  patchCords[patchCordIndex++] = new AudioConnection(lfoMult, 0, filter, 1);
+
+  // Filtro all'output
+  patchCords[patchCordIndex++] = new AudioConnection(filter, 0, i2s1, 0);
+  patchCords[patchCordIndex++] = new AudioConnection(filter, 0, i2s1, 1);
+
+  Serial.print("Total patch cords: ");
+  Serial.println(patchCordIndex);
+}

--- a/examples/Artboard_Sequencer/README.md
+++ b/examples/Artboard_Sequencer/README.md
@@ -1,0 +1,218 @@
+# Artboard Sequencer
+
+Un sequencer musicale polifonico a 8 step con sintetizzatore a 12 note controllato da Artboard.
+
+![Sequencer Concept](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Roland_TR-808_drum_machine.jpg/800px-Roland_TR-808_drum_machine.jpg)
+
+## Descrizione
+
+Questo progetto trasforma Artboard in un potente sequencer musicale step-based, ispirato alle classiche drum machine e sequencer hardware come TR-808, TR-909 e Elektron.
+
+### Caratteristiche
+
+- **8 Step Sequencer**: Registra e riproduce pattern musicali a 8 step
+- **12 Note Polifoniche**: Scala cromatica completa (C3 - B3)
+- **Dual Oscillator Synth**: Due oscillatori per nota con mix regolabile
+- **4 Forme d'onda**: Sine, Sawtooth, Square, Triangle per ogni oscillatore
+- **ADSR Envelope**: Attack e Release regolabili
+- **Filtro Modulato**: State Variable Filter con controllo cutoff
+- **LFO**: Modulazione Low Frequency per effetti wobble
+- **Registrazione in Tempo Reale**: Registra note mentre le suoni
+- **Feedback LED**: Indicatori visivi per step corrente e registrazione
+
+## Hardware Richiesto
+
+- **Artboard** con Teensy 3.6
+- **Teensy Audio Shield** (per l'uscita audio)
+- Altoparlanti o cuffie
+- Switch/Interruttore collegato al pin 28 (per Play/Stop)
+
+## Controlli
+
+### Touch Pads (0-11)
+Suonano le 12 note della scala cromatica:
+- Touch 0: C (Do)
+- Touch 1: C# (Do#)
+- Touch 2: D (Re)
+- Touch 3: D# (Re#)
+- Touch 4: E (Mi)
+- Touch 5: F (Fa)
+- Touch 6: F# (Fa#)
+- Touch 7: G (Sol)
+- Touch 8: G# (Sol#)
+- Touch 9: A (La)
+- Touch 10: A# (La#)
+- Touch 11: B (Si)
+
+### Potenziometri
+
+| Pot | Funzione | Range | Descrizione |
+|-----|----------|-------|-------------|
+| 0 | Attack | 1-500ms | Tempo di attack dell'envelope |
+| 1 | Release | 10-1000ms | Tempo di release dell'envelope |
+| 2 | Osc Mix | 0-100% | Mix tra oscillatore 1 e 2 |
+| 3 | Waveform 1 | 0-3 | Forma d'onda osc 1 (Sine/Saw/Square/Tri) |
+| 4 | Waveform 2 | 0-3 | Forma d'onda osc 2 (Sine/Saw/Square/Tri) |
+| 5 | Filter Cutoff | 100-10000Hz | Frequenza di taglio del filtro |
+| 6 | LFO Rate | 0.1-20Hz | Velocità della modulazione LFO |
+| 7 | LFO Depth | 0-100% | Intensità della modulazione LFO |
+
+**Nota sul Pot 8**: Il progetto originale prevedeva Pot 8 per il BPM, ma Artboard standard ha solo 8 potenziometri (0-7). Puoi:
+- Usare un valore BPM fisso (attualmente 120 BPM)
+- Modificare il codice per usare Pot 7 alternativamente
+- Aggiungere un potenziometro esterno su un pin libero
+
+### Pulsanti (0-7)
+Selezionano lo step da registrare. Tieni premuto un pulsante e suona le note per registrare in quello step.
+
+### Switch On/Off (Pin 28)
+- **ON**: Avvia/Ferma il playback del sequencer
+- Il LED corrispondente allo step corrente si illumina di verde durante il playback
+
+### LED (0-7)
+- **Rosso**: Step in modalità registrazione
+- **Verde**: Step corrente durante playback
+- **Off**: Step inattivo
+
+## Come Usare
+
+### 1. Registrazione
+
+1. **Seleziona uno step**: Tieni premuto uno dei pulsanti (0-7)
+2. **Suona le note**: Mentre tieni premuto il pulsante, tocca i touch pad per suonare le note
+3. **Le note vengono registrate**: Tutte le note suonate mentre il pulsante è premuto vengono salvate in quello step
+4. **Ripeti**: Rilascia il pulsante e registra gli altri step
+
+**Esempio**:
+- Premi Button 0, tocca Touch 0, 4, 7 (accordo C E G), rilascia Button 0
+- Premi Button 1, tocca Touch 2, 5, 9 (accordo D F A), rilascia Button 1
+- Premi Button 2, tocca Touch 4, 8, 11 (accordo E G# B), rilascia Button 2
+
+### 2. Playback
+
+1. **Attiva lo switch** (pin 28 a LOW/ON)
+2. **Il sequencer parte**: Gli step registrati vengono suonati in sequenza
+3. **I LED mostrano lo step corrente** in verde
+4. **Ferma con lo switch**: Riattiva lo switch per fermare
+
+### 3. Tweaking dei Suoni
+
+Durante la registrazione o il playback, regola i potenziometri per:
+- Modificare il timbro (forme d'onda)
+- Regolare attack e release
+- Modulare il filtro con LFO per effetti wobble
+- Creare texture sonore complesse
+
+## Configurazione Audio
+
+Il progetto utilizza la Teensy Audio Library con:
+
+- **24 Oscillatori** (2 per ogni nota)
+- **12 Envelope Generator** (uno per nota)
+- **12 Note Mixer** (combina i 2 oscillatori per nota)
+- **3 Main Mixer** (raggruppano le 12 note)
+- **1 LFO** (modulazione)
+- **1 State Variable Filter** (filtraggio)
+- **I2S Audio Output** (uscita stereo)
+
+### Limiti di Memoria
+
+Teensy 3.6 ha limiti sul numero di oggetti audio e connessioni. Il progetto usa circa 60-70 AudioConnection. Se modifichi il codice e aggiungi altri oggetti, potresti dover:
+- Aumentare `AudioMemory()` nel setup
+- Ridurre il numero di note polifoniche
+- Ottimizzare le connessioni audio
+
+## Consigli e Trucchi
+
+### Pattern Interessanti
+
+- **Bass Pattern**: Usa solo le note basse (Touch 0-4) e forma d'onda Square
+- **Arpeggio**: Registra una nota per step (8 note consecutive)
+- **Accordi**: Suona più note contemporaneamente su ogni step
+- **Poly Rhythm**: Lascia alcuni step vuoti per creare ritmi irregolari
+
+### Sound Design
+
+- **Wobble Bass**: LFO Depth alto, LFO Rate medio, Filter Cutoff basso
+- **Pad Atmosferico**: Attack lungo, Release lungo, Sine waves, LFO lento
+- **Pluck**: Attack corto, Release corto, Sawtooth wave
+- **Lead Synth**: Triangle wave, Filter Cutoff alto, no LFO
+
+### Workflow Creativo
+
+1. Inizia con un semplice pattern di basso (step 0, 2, 4, 6)
+2. Aggiungi armonia negli step dispari (1, 3, 5, 7)
+3. Tweaka i parametri in tempo reale durante il playback
+4. Usa il mix oscillatori per creare movimento timbrico
+
+## Modifiche Possibili
+
+### Aggiungere BPM Control
+```cpp
+// Nel loop(), sostituisci:
+int bpm = 120;
+// Con:
+bpm = map(artboard.pot(7), 0, 1023, 40, 240);
+```
+
+### Aumentare il Numero di Step
+```cpp
+#define NUM_STEPS 16  // Invece di 8
+// Dovrai aggiungere più pulsanti o usare una modalità di page select
+```
+
+### Salvare Pattern su SD Card
+Aggiungi codice per salvare/caricare i pattern `sequence[]` su SD card usando la libreria SD.
+
+### MIDI Out
+Aggiungi supporto MIDI per controllare synth esterni:
+```cpp
+#include <MIDI.h>
+MIDI_CREATE_DEFAULT_INSTANCE();
+// Invia MIDI note on/off durante il playback
+```
+
+### Swing/Shuffle
+Aggiungi un parametro per ritardare gli step dispari:
+```cpp
+if (currentStep % 2 == 1) {
+  delay(swingAmount); // Crea groove
+}
+```
+
+## Troubleshooting
+
+### Nessun suono
+- Verifica che il Teensy Audio Shield sia collegato correttamente
+- Controlla `AudioMemory()` - aumenta se necessario
+- Verifica le connessioni audio nel codice
+
+### Crash o comportamento strano
+- Troppi AudioConnection objects - riduci la complessità
+- Aumenta `AudioMemory()` (max 200-250 su Teensy 3.6)
+
+### LED non funzionano
+- Verifica che FastLED sia installata
+- Controlla che il pin 8 sia collegato ai LED WS2812
+
+### Touch non risponde
+- Regola la soglia touch nel codice: `if (touchValue > 2000)`
+- Prova valori diversi (1000-5000) a seconda del tuo hardware
+
+## Riferimenti
+
+- [Teensy Audio Library](https://www.pjrc.com/teensy/td_libs_Audio.html)
+- [Teensy Audio Design Tool](https://www.pjrc.com/teensy/gui/)
+- [FastLED Library](https://fastled.io/)
+- [TR-808 Wikipedia](https://en.wikipedia.org/wiki/Roland_TR-808)
+
+## Crediti
+
+Ispirato da:
+- Roland TR-808, TR-909 (drum machines)
+- Elektron Digitakt (modern sequencer)
+- Teenage Engineering OP-1 (all-in-one workstation)
+
+## Licenza
+
+MIT License - Daniele Murgia © 2025

--- a/examples/Artboard_Wikipedia_Sonification/Artboard_Wikipedia_Sonification.ino
+++ b/examples/Artboard_Wikipedia_Sonification/Artboard_Wikipedia_Sonification.ino
@@ -213,8 +213,8 @@ void triggerEvent() {
   waveform1.amplitude(0.5);
   envelope1.noteOn();
 
-  // Set LED color
-  artboard.setRGB(r, g, b);
+  // Set all LED color
+  artboard.setAllLEDs(r, g, b);
 
   // Print to serial
   Serial.print("Event: ");


### PR DESCRIPTION
BREAKING CHANGES:
- Aggiunto supporto per LED RGB (WS2812) su pin 8 usando FastLED
- FastLED ora è una dipendenza richiesta della libreria

Modifiche alla libreria Artboard:
- Aggiunte funzioni LED: setLED(), setAllLEDs(), clearLED(), clearAllLEDs(), setBrightness()
- Inizializzazione automatica dei LED al primo utilizzo
- Supporto per 8 LED RGB (WS2812B) collegati al pin 8

Correzioni:
- Corretto esempio Wikipedia_Sonification per usare setAllLEDs() invece di setRGB()
- Aggiornato README con documentazione completa delle funzioni LED
- Aggiunta dipendenza FastLED nelle istruzioni di installazione

Nuovo esempio: Artboard_Sequencer
- Sequencer musicale a 8 step con registrazione in tempo reale
- Sintetizzatore polifonico a 12 note (scala cromatica)
- Dual oscillator per nota con 4 forme d'onda (Sine, Saw, Square, Triangle)
- ADSR envelope con Attack e Release controllabili
- State Variable Filter con modulazione LFO
- Controlli:
  * Touch 0-11: 12 note
  * Pot 0-1: Attack/Release
  * Pot 2: Mix oscillatori
  * Pot 3-4: Selezione forme d'onda
  * Pot 5: Filter Cutoff
  * Pot 6-7: LFO Rate/Depth
  * Button 0-7: Selezione step per registrazione
  * Pin 28: Play/Stop
  * LED 0-7: Indicatori step (rosso=registrazione, verde=playback)
- Include README dettagliato con esempi e sound design tips