### PR TITLE
Fix audio export: add AudioSynthWaveformDc and improve naming

### DIFF
--- a/web/moduli/Audio System Builder.html
+++ b/web/moduli/Audio System Builder.html
@@ -514,6 +514,10 @@
                     <h4><span class="module-color-dot" style="background: #feca57;"></span>Waveform</h4>
                     <p>Forme d'onda multiple</p>
                 </div>
+                <div class="module-item" draggable="true" data-module-type="AudioSynthWaveformDc" data-color="synthesis">
+                    <h4><span class="module-color-dot" style="background: #feca57;"></span>DC Signal</h4>
+                    <p>Segnale DC costante</p>
+                </div>
                 <div class="module-item" draggable="true" data-module-type="AudioSynthNoisePink" data-color="synthesis">
                     <h4><span class="module-color-dot" style="background: #feca57;"></span>Pink Noise</h4>
                     <p>Rumore rosa</p>
@@ -726,33 +730,38 @@ AudioConnection patchCord2(sine2, 0, multiply1, 1);</code>
             'AudioOutputAnalog': { title: 'DAC Output', outputs: 0, inputs: 1,
                 description: 'Output analogico tramite DAC integrato di Teensy (A21/DAC0). 12 bit mono output.',
                 functions: ['analogReference()'],
-                example: 'AudioSynthWaveformSine sine1;\nAudioOutputAnalog dac0;\nAudioConnection patchCord1(sine1, 0, dac0, 0);'
+                example: 'AudioSynthWaveformSine sine1;\nAudioOutputAnalog dac0;\nAudioConnection patchCord1(sine1, 0, dac0, 0);',
+                shortName: 'dac'
             },
-            
+
             // Playback
             'AudioPlaySdWav': { title: 'SD WAV', outputs: 2, inputs: 0,
                 description: 'Riproduce file WAV da SD card. Supporta stereo 16 bit 44.1 kHz.',
                 functions: ['play("filename.wav")', 'stop()', 'isPlaying()'],
-                example: 'void loop() {\n  if (artboard.button(0)>0) {\n    playSdWav1.play("sound.wav");\n  }\n}'
+                example: 'void loop() {\n  if (artboard.button(0)>0) {\n    playSdWav1.play("sound.wav");\n  }\n}',
+                shortName: 'playSdWav'
             },
             'AudioPlayMemory': { title: 'Play Mem', outputs: 1, inputs: 0,
                 description: 'Riproduce array di campioni dalla memoria. Usa wav2sketch per convertire.',
                 functions: ['play(array)', 'stop()'],
-                example: 'AudioPlayMemory sound1;\nsound1.play(AudioSampleKick);'
+                example: 'AudioPlayMemory sound1;\nsound1.play(AudioSampleKick);',
+                shortName: 'playMem'
             },
-            
+
             // Record
             'AudioRecordQueue': { title: 'Record', outputs: 0, inputs: 1,
                 description: 'Registra audio in un buffer circolare. Leggi con readBuffer().',
                 functions: ['begin()', 'available()', 'readBuffer()'],
-                example: 'if (queue1.available() >= 2) {\n  byte buffer[256];\n  memcpy(buffer, queue1.readBuffer(), 256);\n  queue1.freeBuffer();\n}'
+                example: 'if (queue1.available() >= 2) {\n  byte buffer[256];\n  memcpy(buffer, queue1.readBuffer(), 256);\n  queue1.freeBuffer();\n}',
+                shortName: 'queue'
             },
             
             // Synthesis
             'AudioSynthWaveformSine': { title: 'Sine Osc', outputs: 1, inputs: 0,
                 description: 'Oscillatore sinusoidale puro. ',
                 functions: ['frequency(hz)', 'amplitude(0.0-1.0)'],
-                example: 'sine1.frequency(440.0);\nsine1.amplitude(0.5);'
+                example: 'sine1.frequency(440.0);\nsine1.amplitude(0.5);',
+                shortName: 'sine'
             },
             'AudioSynthWaveform': { title: 'Waveform', outputs: 1, inputs: 0,
                 description: 'Oscillatore multi-forma d\'onda. Puoi scegliere tra Sine, Sawtooth, Square e Triangle. Perfetto per sintesi subtrattiva.',
@@ -763,85 +772,106 @@ AudioConnection patchCord2(sine2, 0, multiply1, 1);</code>
                     'WAVEFORM_SQUARE': 'Onda quadra - suono hollow, armoniche dispari',
                     'WAVEFORM_TRIANGLE': 'Triangolare - simile a sine ma con armoniche dispari'
                 },
-                example: 'waveform1.begin(WAVEFORM_SAWTOOTH);\nwaveform1.frequency(220);\nwaveform1.amplitude(0.8);\n\n// Cambia forma d\'onda:\nwaveform1.begin(WAVEFORM_SQUARE);\n\n// Square con PWM:\nwaveform1.pulseWidth(0.3);'
+                example: 'waveform1.begin(WAVEFORM_SAWTOOTH);\nwaveform1.frequency(220);\nwaveform1.amplitude(0.8);\n\n// Cambia forma d\'onda:\nwaveform1.begin(WAVEFORM_SQUARE);\n\n// Square con PWM:\nwaveform1.pulseWidth(0.3);',
+                shortName: 'waveform'
+            },
+            'AudioSynthWaveformDc': { title: 'DC Signal', outputs: 1, inputs: 0,
+                description: 'Genera un segnale DC costante. Ideale come sorgente di controllo per VCA, modulazione, envelope manuale.',
+                functions: ['amplitude(0.0-1.0)'],
+                example: 'envelope.amplitude(0.5);  // Imposta livello DC a 50%\n\n// Esempio VCA:\nAudioSynthWaveformSine sine1;\nAudioSynthWaveformDc envelope;\nAudioEffectMultiply vca;\nenvelope.amplitude(0.8);',
+                shortName: 'envelope'
             },
             'AudioSynthNoisePink': { title: 'Pink Noise', outputs: 1, inputs: 0,
                 description: 'Rumore rosa (1/f). -3dB per ottava. Più naturale del rumore bianco.',
                 functions: ['amplitude(0.0-1.0)'],
-                example: 'pink1.amplitude(0.3);'
+                example: 'pink1.amplitude(0.3);',
+                shortName: 'pink'
             },
             'AudioSynthNoiseWhite': { title: 'White Noise', outputs: 1, inputs: 0,
                 description: 'Rumore bianco. Tutte le frequenze con stessa ampiezza.',
                 functions: ['amplitude(0.0-1.0)'],
-                example: 'white1.amplitude(0.3);'
+                example: 'white1.amplitude(0.3);',
+                shortName: 'white'
             },
             
             // Effects
             'AudioEffectDelay': { title: 'Delay', outputs: 8, inputs: 1,
                 description: 'Delay line con 8 tap. Fino a 333ms. Usa memoria interna.',
                 functions: ['delay(channel, milliseconds)'],
-                example: 'delay1.delay(0, 200);  // 200ms sul tap 0\ndelay1.delay(1, 400);  // 400ms sul tap 1'
+                example: 'delay1.delay(0, 200);  // 200ms sul tap 0\ndelay1.delay(1, 400);  // 400ms sul tap 1',
+                shortName: 'delay'
             },
             'AudioEffectFreeverb': { title: 'Freeverb', outputs: 1, inputs: 1,
                 description: 'Algoritmo Freeverb mono. Riverbero di alta qualità.',
                 functions: ['roomsize(0.0-1.0)', 'damping(0.0-1.0)'],
-                example: 'freeverb1.roomsize(0.8);\nfreeverb1.damping(0.5);'
+                example: 'freeverb1.roomsize(0.8);\nfreeverb1.damping(0.5);',
+                shortName: 'reverb'
             },
             'AudioEffectEnvelope': { title: 'Envelope', outputs: 1, inputs: 1,
                 description: 'Generatore ADSR. Modula ampiezza nel tempo.',
                 functions: ['attack(ms)', 'decay(ms)', 'sustain(level)', 'release(ms)', 'noteOn()', 'noteOff()'],
-                example: 'envelope1.attack(10);\nenvelope1.decay(35);\nenvelope1.sustain(0.5);\nenvelope1.release(300);\nenvelope1.noteOn();'
+                example: 'envelope1.attack(10);\nenvelope1.decay(35);\nenvelope1.sustain(0.5);\nenvelope1.release(300);\nenvelope1.noteOn();',
+                shortName: 'adsr'
             },
             'AudioEffectMultiply': { title: 'Multiply', outputs: 1, inputs: 2,
                 description: 'Moltiplica due segnali (ring modulation). Crea effetti metallici.',
                 functions: [],
-                example: 'AudioConnection patchCord1(sine1, 0, multiply1, 0);\nAudioConnection patchCord2(sine2, 0, multiply1, 1);'
+                example: 'AudioConnection patchCord1(sine1, 0, multiply1, 0);\nAudioConnection patchCord2(sine2, 0, multiply1, 1);',
+                shortName: 'vca'
             },
-            
+
             // Filters
             'AudioFilterStateVariable': { title: 'State Var', outputs: 3, inputs: 1,
                 description: 'Filtro state variable. 3 output simultanei: lowpass, bandpass, highpass.',
                 functions: ['frequency(hz)', 'resonance(0.7-5.0)', 'octaveControl(octaves)'],
-                example: 'filter1.frequency(1000);\nfilter1.resonance(1.5);\n// Usa output 0=LP, 1=BP, 2=HP'
+                example: 'filter1.frequency(1000);\nfilter1.resonance(1.5);\n// Usa output 0=LP, 1=BP, 2=HP',
+                shortName: 'filter'
             },
             'AudioFilterBiquad': { title: 'Biquad', outputs: 1, inputs: 1,
                 description: 'Filtro IIR biquad. Configura come lowpass, highpass, bandpass, notch.',
                 functions: ['setLowpass(stage, freq, Q)', 'setHighpass(stage, freq, Q)', 'setBandpass(stage, freq, Q)', 'setNotch(stage, freq, Q)'],
-                example: 'biquad1.setLowpass(0, 800, 0.707);  // Butterworth\nbiquad1.setHighpass(1, 200, 0.707);'
+                example: 'biquad1.setLowpass(0, 800, 0.707);  // Butterworth\nbiquad1.setHighpass(1, 200, 0.707);',
+                shortName: 'biquad'
             },
-            
+
             // Mixers
             'AudioMixer4': { title: 'Mixer 4', outputs: 1, inputs: 4,
                 description: 'Mixer a 4 canali. Controlla gain di ogni canale.',
                 functions: ['gain(channel, level)'],
-                example: 'mixer1.gain(0, 0.5);  // canale 0 a 50%\nmixer1.gain(1, 0.8);  // canale 1 a 80%'
+                example: 'mixer1.gain(0, 0.5);  // canale 0 a 50%\nmixer1.gain(1, 0.8);  // canale 1 a 80%',
+                shortName: 'mixer'
             },
             'AudioAmplifier': { title: 'Amplifier', outputs: 1, inputs: 1,
                 description: 'Amplificatore/attenuatore semplice. Controllo volume.',
                 functions: ['gain(level)'],
-                example: 'amp1.gain(0.5);  // 50% volume\namp1.gain(2.0);  // +6dB amplificazione'
+                example: 'amp1.gain(0.5);  // 50% volume\namp1.gain(2.0);  // +6dB amplificazione',
+                shortName: 'amp'
             },
-            
+
             // Analysis
             'AudioAnalyzePeak': { title: 'Peak', outputs: 0, inputs: 1,
                 description: 'Misura ampiezza di picco. Utile per VU meter.',
                 functions: ['available()', 'read()'],
-                example: 'if (peak1.available()) {\n  float val = peak1.read();\n  Serial.println(val);\n}'
+                example: 'if (peak1.available()) {\n  float val = peak1.read();\n  Serial.println(val);\n}',
+                shortName: 'peak'
             },
             'AudioAnalyzeRMS': { title: 'RMS', outputs: 0, inputs: 1,
                 description: 'Calcola RMS (potenza media). Migliore per loudness percepito.',
                 functions: ['available()', 'read()'],
-                example: 'if (rms1.available()) {\n  float level = rms1.read();\n}'
+                example: 'if (rms1.available()) {\n  float level = rms1.read();\n}',
+                shortName: 'rms'
             },
             'AudioAnalyzeFFT256': { title: 'FFT 256', outputs: 0, inputs: 1,
                 description: 'FFT a 256 punti. Analisi spettrale veloce.',
                 functions: ['available()', 'read(bin)', 'read(first, last)'],
-                example: 'if (fft256.available()) {\n  for (int i=0; i<128; i++) {\n    float level = fft256.read(i);\n  }\n}'
+                example: 'if (fft256.available()) {\n  for (int i=0; i<128; i++) {\n    float level = fft256.read(i);\n  }\n}',
+                shortName: 'fft256'
             },
             'AudioAnalyzeFFT1024': { title: 'FFT 1024', outputs: 0, inputs: 1,
                 description: 'FFT a 1024 punti. Maggiore risoluzione in frequenza.',
                 functions: ['available()', 'read(bin)'],
-                example: 'if (fft1024.available()) {\n  float bass = fft1024.read(0, 10);  // 0-430 Hz\n}'
+                example: 'if (fft1024.available()) {\n  float bass = fft1024.read(0, 10);  // 0-430 Hz\n}',
+                shortName: 'fft1024'
             }
         };
 
@@ -1277,15 +1307,36 @@ Artboard artboard;
 `;
 
             const typeCounts = {};
+            const typeModules = {};
             const moduleNames = {};
 
+            // Prima passata: conta i moduli per tipo
             modules.forEach(module => {
-                const baseType = module.type.replace('Audio', '').replace('Synth', '').replace('Effect', '').replace('Filter', '').replace('Analyze', '').toLowerCase();
+                const config = moduleConfigs[module.type];
+                const baseType = config && config.shortName ? config.shortName : module.type.replace('Audio', '').replace('Synth', '').replace('Effect', '').replace('Filter', '').replace('Analyze', '').toLowerCase();
                 if (!typeCounts[baseType]) {
                     typeCounts[baseType] = 0;
+                    typeModules[baseType] = [];
                 }
                 typeCounts[baseType]++;
-                moduleNames[module.id] = baseType + typeCounts[baseType];
+                typeModules[baseType].push(module.id);
+            });
+
+            // Seconda passata: assegna i nomi
+            modules.forEach(module => {
+                const config = moduleConfigs[module.type];
+                const baseType = config && config.shortName ? config.shortName : module.type.replace('Audio', '').replace('Synth', '').replace('Effect', '').replace('Filter', '').replace('Analyze', '').toLowerCase();
+
+                // DAC usa sempre 0 (perché si riferisce al pin hardware DAC0)
+                if (baseType === 'dac') {
+                    const index = typeModules[baseType].indexOf(module.id);
+                    moduleNames[module.id] = baseType + index;
+                }
+                // Tutti gli altri moduli usano numeri partendo da 1
+                else {
+                    const index = typeModules[baseType].indexOf(module.id) + 1;
+                    moduleNames[module.id] = baseType + index;
+                }
             });
 
             modules.forEach(module => {


### PR DESCRIPTION
- Added AudioSynthWaveformDc module for DC signal generation (essential for VCA)
- Added shortName property to all module configs for better variable naming
- Improved export logic to generate cleaner, more descriptive variable names
  - sine1, vca1, envelope1, etc. instead of waveformsine1, multiply1, etc.
  - DAC always uses 0 (dac0) to match hardware pin naming
- Export now generates code compatible with Teensy Audio System Design Tool

The AudioSynthWaveformDc module is critical for creating VCA (Voltage Controlled Amplifier) patches, as it provides a constant DC signal that can be used to control the amplitude of other signals through the multiply module.